### PR TITLE
added gnome extensions arcmenu, backslide, dash to panel and gsnap

### DIFF
--- a/resources/options/gnome_extension_scripts.json
+++ b/resources/options/gnome_extension_scripts.json
@@ -2,7 +2,7 @@
     {
         "name": "ArcMenu",
         "description": "Windows-like Application menu for GNOME Shell",
-        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/3628/arcmenu/)",
+        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/3628/arcmenu)",
         "default_state": false,
         "category": "gnome_extension",
         "operation_type": "script",
@@ -36,7 +36,7 @@
         "name": "BackSlide",
         "description": "Automatic background-image (wallpaper) slideshow for Gnome Shell",
         "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/543/backslide)",
-        "default_state": true,
+        "default_state": false,
         "category": "gnome_extension",
         "operation_type": "script",
         "operation_args": [
@@ -79,7 +79,7 @@
     {
         "name": "Dash to Panel",
         "description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+.",
-        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/307/dash-to-dock)",
+        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/1160/dash-to-panel)",
         "default_state": false,
         "category": "gnome_extension",
         "operation_type": "script",

--- a/resources/options/gnome_extension_scripts.json
+++ b/resources/options/gnome_extension_scripts.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "ArcMenu",
+        "description": "Windows-like Application menu for GNOME Shell",
+        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/3628/arcmenu/)",
+        "default_state": false,
+        "category": "gnome_extension",
+        "operation_type": "script",
+        "operation_args": [
+            "gnome_extension/arcmenu"
+        ]
+    },
+    {
         "name": "AppIndicator and KStatusNotifierItem Support",
         "description": "Enables support for tray icons",
         "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/615/appindicator-support)",
@@ -19,6 +30,17 @@
         "operation_type": "script",
         "operation_args": [
             "gnome_extension/background_logo"
+        ]
+    },
+    {
+        "name": "BackSlide",
+        "description": "Automatic background-image (wallpaper) slideshow for Gnome Shell",
+        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/543/backslide)",
+        "default_state": true,
+        "category": "gnome_extension",
+        "operation_type": "script",
+        "operation_args": [
+            "gnome_extension/backslide"
         ]
     },
     {
@@ -55,6 +77,17 @@
         ]
     },
     {
+        "name": "Dash to Panel",
+        "description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+.",
+        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/307/dash-to-dock)",
+        "default_state": false,
+        "category": "gnome_extension",
+        "operation_type": "script",
+        "operation_args": [
+            "gnome_extension/dash_to_panel"
+        ]
+    },
+    {
         "name": "ddterm",
         "description": "Provides a drop-down terminal on a hotkey press",
         "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/3780/ddterm)",
@@ -85,6 +118,17 @@
         "operation_type": "script",
         "operation_args": [
             "gnome_extension/gsconnect"
+        ]
+    },
+    {
+        "name": "gSnap",
+        "description": "Organize windows in customizable snap zones like FancyZones on Windows.",
+        "documentation_link": "[View on Gnome Extensions](https://extensions.gnome.org/extension/4442/gsnap)",
+        "default_state": false,
+        "category": "gnome_extension",
+        "operation_type": "script",
+        "operation_args": [
+            "gnome_extension/gsnap"
         ]
     },
     {

--- a/resources/profiles/WindowsKDELike_gaming_nvidia.profile
+++ b/resources/profiles/WindowsKDELike_gaming_nvidia.profile
@@ -1,0 +1,49 @@
+{
+    "application": [
+        "Archive Manager",
+        "Bitwarden",
+        "FreeTube",
+        "Gnome Extension Manager",
+        "LibreWolf",
+        "MangoHud",
+        "OnlyOffice Desktop Editors",
+        "ProtonUp-Qt",
+        "qBittorrent",
+        "Signal Desktop",
+        "Spotify",
+        "Steam",
+        "Steam ROM Manager",
+        "VLC Media Player"
+    ],
+    "emulator": [
+        "Dolphin Emulator",
+        "Ryujinx"
+    ],
+    "game": [],
+    "gnome_extension": [
+        "AppIndicator and KStatusNotifierItem Support",
+        "ArcMenu",
+        "BackSlide",
+        "Dash to Panel",
+        "GSConnect",
+        "NoAnnoyance"
+    ],
+    "setting": [
+        "Clock - Apply AM/PM Format",
+        "Shell - Apply Dark Mode",
+        "Shell - Disable Hot Corners",
+        "Shell - Enable Minimize and Maximize Buttons",
+        "System - Disable Automatic Problem Reporting",
+        "System - Disable Location Services"
+    ],
+    "system": [
+        "Install Nvidia Drivers",
+        "Install Unrar",
+        "Install Updates",
+        "Remove Gnome Bloat",
+        "Remove LibreOffice",
+        "Set App Picker Layout",
+        "Set Favorite Apps"
+    ],
+    "vpn": []
+}

--- a/resources/profiles/WindowsKDELike_gaming_nvidia_dev.profile
+++ b/resources/profiles/WindowsKDELike_gaming_nvidia_dev.profile
@@ -1,0 +1,51 @@
+{
+    "application": [
+        "Archive Manager",
+        "Bitwarden",
+        "FreeTube",
+        "Gnome Extension Manager",
+        "JetBrains Toolbox",
+        "LibreWolf",
+        "MangoHud",
+        "OnlyOffice Desktop Editors",
+        "ProtonUp-Qt",
+        "qBittorrent",
+        "Signal Desktop",
+        "Spotify",
+        "Steam",
+        "Steam ROM Manager",
+        "Unity Hub",
+        "VLC Media Player"
+    ],
+    "emulator": [
+        "Dolphin Emulator",
+        "Ryujinx"
+    ],
+    "game": [],
+    "gnome_extension": [
+        "AppIndicator and KStatusNotifierItem Support",
+        "ArcMenu",
+        "BackSlide",
+        "Dash to Panel",
+        "GSConnect",
+        "NoAnnoyance"
+    ],
+    "setting": [
+        "Clock - Apply AM/PM Format",
+        "Shell - Apply Dark Mode",
+        "Shell - Disable Hot Corners",
+        "Shell - Enable Minimize and Maximize Buttons",
+        "System - Disable Automatic Problem Reporting",
+        "System - Disable Location Services"
+    ],
+    "system": [
+        "Install Nvidia Drivers",
+        "Install Unrar",
+        "Install Updates",
+        "Remove Gnome Bloat",
+        "Remove LibreOffice",
+        "Set App Picker Layout",
+        "Set Favorite Apps"
+    ],
+    "vpn": []
+}

--- a/resources/profiles/WindowsKDELike_minimal_nvidia.profile
+++ b/resources/profiles/WindowsKDELike_minimal_nvidia.profile
@@ -1,0 +1,35 @@
+{
+    "application": [
+        "Archive Manager",
+        "Gnome Extension Manager",
+        "OnlyOffice Desktop Editors",
+        "VLC Media Player"
+    ],
+    "emulator": [],
+    "game": [],
+    "gnome_extension": [
+        "AppIndicator and KStatusNotifierItem Support",
+        "ArcMenu",
+        "BackSlide",
+        "Dash to Panel",
+        "GSConnect",
+        "NoAnnoyance"
+    ],
+    "setting": [
+        "Clock - Apply AM/PM Format",
+        "Shell - Disable Hot Corners",
+        "Shell - Enable Minimize and Maximize Buttons",
+        "System - Disable Automatic Problem Reporting",
+        "System - Disable Location Services"
+    ],
+    "system": [
+        "Install Nvidia Drivers",
+        "Install Unrar",
+        "Install Updates",
+        "Remove Gnome Bloat",
+        "Remove LibreOffice",
+        "Set App Picker Layout",
+        "Set Favorite Apps"
+    ],
+    "vpn": []
+}

--- a/src/scripts/gnome_extension/arcmenu.py
+++ b/src/scripts/gnome_extension/arcmenu.py
@@ -1,0 +1,12 @@
+from utils.gnome_extension_utils import enable_extension, install_remote_extension
+
+ID: str = "arcmenu@arcmenu.com"
+
+
+def execute():
+    """
+    Application menu for GNOME Shell
+    :return: None
+    """
+    install_remote_extension(ID)
+    enable_extension(ID)

--- a/src/scripts/gnome_extension/backslide.py
+++ b/src/scripts/gnome_extension/backslide.py
@@ -1,0 +1,12 @@
+from utils.gnome_extension_utils import enable_extension, install_remote_extension
+
+ID: str = "backslide@codeisland.org"
+
+
+def execute():
+    """
+    Automatic background-image (wallpaper) slideshow for Gnome Shell.
+    :return: None
+    """
+    install_remote_extension(ID)
+    enable_extension(ID)

--- a/src/scripts/gnome_extension/dash_to_panel.py
+++ b/src/scripts/gnome_extension/dash_to_panel.py
@@ -1,0 +1,12 @@
+from utils.gnome_extension_utils import enable_extension, install_remote_extension
+
+ID: str = "dash-to-panel@jderose9.github.com"
+
+
+def execute():
+    """
+    An icon taskbar for the Gnome Shell
+    :return: None
+    """
+    install_remote_extension(ID)
+    enable_extension(ID)

--- a/src/scripts/gnome_extension/dash_to_panel.py
+++ b/src/scripts/gnome_extension/dash_to_panel.py
@@ -1,4 +1,5 @@
-from utils.gnome_extension_utils import enable_extension, install_remote_extension
+from utils.dnf_utils import install_packages
+from utils.gnome_extension_utils import enable_extension
 
 ID: str = "dash-to-panel@jderose9.github.com"
 
@@ -8,5 +9,5 @@ def execute():
     An icon taskbar for the Gnome Shell
     :return: None
     """
-    install_remote_extension(ID)
-    enable_extension(ID)
+    install_packages(["gnome-shell-extension-dash-to-panel"])
+    enable_extension("dash-to-panel@jderose9.github.com")

--- a/src/scripts/gnome_extension/gsnap.py
+++ b/src/scripts/gnome_extension/gsnap.py
@@ -1,0 +1,12 @@
+from utils.gnome_extension_utils import enable_extension, install_remote_extension
+
+ID: str = "gSnap@micahosborne"
+
+
+def execute():
+    """
+    Organize windows in customizable snap zones like FancyZones on Windows.
+    :return: None
+    """
+    install_remote_extension(ID)
+    enable_extension(ID)


### PR DESCRIPTION
using gnome extension utils to install and enable addition extensions. Backslide enabled by default.